### PR TITLE
zig-mach: Add version 2024.1.0-mach

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ scoop install zig
 ## Tools in this bucket:
 - **zig** - *zig compiler* 
 - **zig-dev**[^1] - *zig compiler (development version)*
+- **zig-mach** - *zig compiler (machs nominated zig version)*
 - **zls** - *language server for zig*
 
 [^1]: zig-dev is aliased as both *zig* and *zig-dev* unless zig stable is also installed (in which case *zig* will execute zig stable)

--- a/bucket/zig-mach.json
+++ b/bucket/zig-mach.json
@@ -1,0 +1,32 @@
+{
+    "version": "2024.1.0-mach",
+    "description": "General-purpose programming language designed for robustness, optimality, and maintainability.",
+    "homepage": "https://ziglang.org/",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://pkg.machengine.org/zig/zig-windows-x86_64-0.12.0-dev.2063+804cee3b9.zip",
+            "hash": "8dc5ecd7a0871d1d024e50fffdb51f0aef96c7023d9a935c598610a51f3c725c",
+            "extract_dir": "zig-windows-x86_64-0.12.0-dev.2063+804cee3b9"
+        },
+        "32bit": {
+            "url": "https://pkg.machengine.org/zig/zig-windows-x86-0.12.0-dev.2063+804cee3b9.zip",
+            "hash": "cab356caec718b6237e83d4c84bc278d06e84bda76c13d4aed2c211ab204de3b",
+            "extract_dir": "zig-windows-x86-0.12.0-dev.2063+804cee3b9"
+        },
+        "arm64": {
+            "url": "https://pkg.machengine.org/zig/zig-windows-aarch64-0.12.0-dev.2063+804cee3b9.zip",
+            "hash": "299d5455cbb4a2370a6675a79f32b01956ffbdda8d70bb78e8a1671940ecd97",
+            "extract_dir": "zig-windows-aarch64-0.12.0-dev.2063+804cee3b9"
+        }
+    },
+    "bin": "zig.exe",
+    "checkver": {
+        "url": "https://machengine.org/zig/index.json",
+        "jsonpath": "$.master.version",
+        "regex": "(?<version>[\\w._-]+)\\+(?<commit>[0-9a-f]+)"
+    },
+}


### PR DESCRIPTION
The first nominated version for mach. Zig 2024.1.0-mach and 0.12.0-dev.2063+804cee3b9 are identical.

Unfortunately I was unable to install zig with scoop install zig@0.12.0-dev.2063+804cee3b9 . It appears that https://ziglang.org/download/index.json only has the latest 0.12.0-dev.